### PR TITLE
みため直し

### DIFF
--- a/app/assets/stylesheets/account/form.scss
+++ b/app/assets/stylesheets/account/form.scss
@@ -4,7 +4,7 @@
 div#wrapper{
     div#container{
         div#generic-form{
-            width: 480px;
+            width: 700px;
             margin: $wide * 2 auto;
             padding: $wide * 2;
             border: solid 1px $dark-gray;
@@ -14,6 +14,18 @@ div#wrapper{
 
             
             form{
+                table{
+                    width: 100%;
+                    th{
+                        width: auto;
+                    }
+                    label.required:after{
+                        content: '*';
+                        padding-left: $narrow;
+                        color: $red;
+                    }
+                }
+
                 div{
                     padding: $wide;
                     label{

--- a/app/controllers/account/admin_controller.rb
+++ b/app/controllers/account/admin_controller.rb
@@ -84,7 +84,7 @@ class Account::AdminController < Account::Base
 
     def result
         pp "検索を始めます。"
-        @searches = Member.where('created_at >= :years_ago', :years_ago => Time.now-60.years).where("last_name ilike '%#{params[:search_text]}%'")
+        @searches = Member.where('created_at >= :years_ago', :years_ago => Time.now-60.years).where("last_name ilike '%#{params[:search_text]}%'").order(:id)
         # @searches = eval(params[:model]).where('created_at >= :years_ago', :years_ago => Time.now-60.years).where("last_name LIKE ? '%#{params[:search_text]}%'")
         pp @searches
     end

--- a/app/controllers/account/members_controller.rb
+++ b/app/controllers/account/members_controller.rb
@@ -3,10 +3,8 @@ class Account::MembersController < Account::Base
     def index
         @current_account = current_account
         @current_member = current_member
-        @member = Member.order(:first_name, :last_name)
-        @member = @member.page(params[:page])
-        
-        
+        @member = Member.order(updated_at: "DESC")
+        @member = @member.page(params[:page])  
     end
     
     def detail

--- a/app/views/account/admin/_form.html.erb
+++ b/app/views/account/admin/_form.html.erb
@@ -1,38 +1,71 @@
 <div class="notes">
     <span class="mark">*</span> 印の付いた項目は入力必須です。
 </div>
-<div>
-    <%= f.label :last_name, "カナ(名字)", class: "required" %>
-    <%= f.text_field :last_name, size: 32, required: true %>
-</div>   
-<div>
-    <%= f.label :first_name, "カナ(名前)", class: "required" %>
-    <%= f.text_field :first_name, size: 32, required: true %>
-</div>
-
-<div>
-    <%= f.label :last_name_phonetic, "カナ(名字)", class: "required" %>
-    <%= f.text_field :last_name_phonetic, size: 32, required: true %>
-</div>
-<div>
-    <%= f.label :first_name_phonetic, "カナ(名前)", class: "required" %>
-    <%= f.text_field :first_name_phonetic, size: 32, required: true %>
-</div>
-<div>
-    <%= f.label :deleted_at, "退職日" %>
-    <%= f.date_field :deleted_at, size: 32 %>
-</div>
-<%= f.fields_for :account,(@m.account) do |i| %>
-    <div>
-    <%= i.label :mail_address, "メールアドレス", class: "required" %>
-    <%= i.text_field :mail_address, size:30%>
-    </div>
-    <div>
-    <%= i.label :password, "パスワード", class: "required" %>
-    <%= i.password_field :password, class: "none", size:25%>
-    </div>
-    <div>
-    <%= i.label :admin_flag, "adminの権限", class: "required" %>
-    <%= i.check_box :admin_flag%>
-    </div>
-<% end %>
+<table>
+    <tr>
+        <th>
+            <%= f.label :last_name, "名前(姓)", class: "required" %>
+        </th>
+        <td>
+            <%= f.text_field :last_name, size: 32, required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :first_name, "名前(名)", class: "required" %>
+        </th>
+        <td>
+            <%= f.text_field :first_name, size: 32, required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :last_name_phonetic, "ふりがな(姓)", class: "required" %>
+        </th>
+        <td>
+            <%= f.text_field :last_name_phonetic, size: 32, required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :first_name_phonetic, "ふりがな(名)", class: "required" %>
+        </th>
+        <td>
+            <%= f.text_field :first_name_phonetic, size: 32, required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :deleted_at, "退職日" %>
+        </th>
+        <td>
+            <%= f.date_field :deleted_at, size: 32 %>
+        </td>
+    </tr>
+    <%= f.fields_for :account,(@m.account) do |a| %>
+        <tr>
+            <th>
+                <%= a.label :mail_address, "メールアドレス", class: "required" %>
+            </th>
+            <td>
+                <%= a.email_field :mail_address, size: 32, required: true %>
+            </td>
+        </tr>
+        <tr>
+            <th>
+                <%= a.label :password, "パスワード", class: "required" %>
+            </th>
+            <td>
+                <%= a.password_field :password, size: 32, class:"none", required: true %>
+            </td>
+        </tr>
+        <tr>
+            <th>
+                <%= a.label :admin_flag, "管理者権限" %>
+            </th>
+            <td>
+                <%= a.check_box :admin_flag %>
+            </td>
+        </tr>
+    <% end %>
+</table>

--- a/app/views/account/admin/_form2.html.erb
+++ b/app/views/account/admin/_form2.html.erb
@@ -1,90 +1,184 @@
-<div>
-    <%= f.label :face_photo_path, "写真番号設定" %>
-    <%= f.file_field :face_photo_path, accept: 'image/png,image/gif,image/jpeg' %>
+<div class="notes">
+    <span class="mark">*</span>印の項目は入力が必要です。
 </div>
-<div>
-    <%= f.label :last_name, "名前（姓）" %>
-    <%= f.text_field :last_name, :placeholder => "姓", size: 32, required: true %>
-</div>
-<div>
-    <%= f.label :first_name, "名前（名）" %>
-    <%= f.text_field :first_name, :placeholder => "名", size: 32, required: true %>
-</div>
-<div>
-    <%= f.label :last_name_phonetic, "ふりがな（姓）" %>
-    <%= f.text_field :last_name_phonetic, :placeholder => "ふりがな", size: 32, required: true %>
-</div>
-<div>
-    <%= f.label :first_name_phonetic, "ふりがな（名）" %>
-    <%= f.text_field :first_name_phonetic, :placeholder => "ふりがな", size: 32, required: true %>
-</div>
-<div>
-    <%= f.label :birth_year_month, "誕生年月" %>
-    <%= f.number_field :birth_year_month, :placeholder => "YYYYMMDD", size: 32, required: true %>
-</div>
-<div>
-    <%= f.label :joining_year, "入社日" %>
-    <%= f.number_field :joining_year, :placeholder => "YYYYMMDD", size: 32, required: true %>
-</div>
-<%= f.fields_for :account do |a| %>
-    <div>
-        <%= a.label :mail_address, "メールアドレス" %>
-        <%= a.email_field :mail_address, :placeholder => "メールアドレス", size: 32, required: true %>
-    </div>
-    <div>
-        <%= a.label :password, "パスワード" %>
-        <%= a.password_field :password, :placeholder => "パスワード", size: 32, class:"none", required: true %>
-    </div>
-    <div>
-        <%= a.label :admin_flag, "管理者権限" %>
-        <%= a.check_box :admin_flag%>
-    </div>
-<% end %>
-<div>
-    <%= f.label :one_word_comment, "一言コメント" %>
-    <%= f.text_field :one_word_comment, :placeholder => "自己アピールを一言で", size: 32 %>
-</div>
-<div>
-    <%= f.label :personality, "性格" %>
-    <%= f.text_field :personality, :placeholder => "自分の性格について", size: 32 %>
-</div>
-<div>
-    <%= f.label :hobby, "趣味" %>
-    <%= f.text_field :hobby, :placeholder => "趣味", size: 32 %>
-</div>
-<div>
-    <%= f.label :favorite_things, "好きなもの" %>
-    <%= f.text_field :favorite_things, :placeholder => "好きなものや好きなことをなんでも", size: 32 %>
-</div>
-<div>
-    <%= f.label :hate_things, "嫌いなもの" %>
-    <%= f.text_field :hate_things, :placeholder => "嫌いなものや嫌いなことをなんでも", size: 32 %>
-</div>
-<div>
-    <%= f.label :strong_point, "長所" %>
-    <%= f.text_field :strong_point, :placeholder => "自分の長所を", size: 32 %>
-</div>
-<div>
-    <%= f.label :week_point, "短所" %>
-    <%= f.text_field :week_point, :placeholder => "自分の短所を", size: 32 %>
-</div>
-<div>
-    <%= f.label :special_skill, "得意なこと" %>
-    <%= f.text_field :special_skill, :placeholder => "得意なこと", size: 32 %>
-</div>
-<div>
-    <%= f.label :week_things, "苦手なこと" %>
-    <%= f.text_field :week_things, :placeholder => "苦手なこと", size: 32%>
-</div>
-<div>
-    <%= f.label :happy_done_things, "されて嬉しいこと" %>
-    <%= f.text_field :happy_done_things, :placeholder => "されて嬉しいこと", size: 32 %>
-</div>
-<div>
-    <%= f.label :disgusted_things, "されたら嫌なこと" %>
-    <%= f.text_field :disgusted_things, :placeholder => "されたら嫌いなこと", size: 32 %>
-</div>
-<div>
-    <%= f.label :freedom_message, "自由記入欄" %>
-    <%= f.text_field :freedom_message, :placeholder => "自由に書いてください", size: 32 %>
-</div>
+<table class="new-form">
+    <tr>
+        <th>
+            <%= f.label :face_photo_path, "写真登録" %>
+        </th>
+        <td>
+            <%= f.file_field :face_photo_path, accept: 'image/png,image/gif,image/jpeg' %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :last_name, "名前(姓)", class: "required" %>
+        </th>
+        <td>
+            <%= f.text_field :last_name, :placeholder => "姓", size: 32, required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :first_name, "名前(名)", class: "required" %>
+        </th>
+        <td>
+            <%= f.text_field :first_name, :placeholder => "名", size: 32, required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :last_name_phonetic, "ふりがな(姓)", class: "required" %>
+        </th>
+        <td>
+            <%= f.text_field :last_name_phonetic, :placeholder => "ふりがな", size: 32, required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :first_name_phonetic, "ふりがな(名)", class: "required" %>
+        </th>
+        <td>
+            <%= f.text_field :first_name_phonetic, :placeholder => "ふりがな", size: 32, required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :birth_year_month, "誕生年月", class: "required" %>
+        </th>
+        <td>
+            <%= f.number_field :birth_year_month, :placeholder => "YYYYMMDD", required: true %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :joining_year, "入社日", class: "required" %>
+        </th>
+        <td>
+            <%= f.number_field :joining_year, :placeholder => "YYYYMMDD", required: true %>
+        </td>
+    </tr>
+    <%= f.fields_for :account do |a| %>
+        <tr>
+            <th>
+                <%= a.label :mail_address, "メールアドレス", class: "required" %>
+            </th>
+            <td>
+                <%= a.email_field :mail_address, :placeholder => "メールアドレス", size: 32, required: true %>
+            </td>
+        </tr>
+        <tr>
+            <th>
+                <%= a.label :password, "パスワード", class: "required" %>
+            </th>
+            <td>
+                <%= a.password_field :password, :placeholder => "パスワード", size: 32, class:"none", required: true %>
+            </td>
+        </tr>
+        <tr>
+            <th>
+                <%= a.label :admin_flag, "管理者権限" %>
+            </th>
+            <td>
+                <%= a.check_box :admin_flag%>
+            </td>
+        </tr>
+    <% end %>
+    <tr>
+        <th>
+            <%= f.label :one_word_comment, "一言コメント" %>
+        </th>
+        <td>
+            <%= f.text_field :one_word_comment, :placeholder => "自己アピールを一言で", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :personality, "性格" %>
+        </th>
+        <td>
+            <%= f.text_field :personality, :placeholder => "自分の性格について", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :hobby, "趣味" %>
+        </th>
+        <td>
+            <%= f.text_field :hobby, :placeholder => "趣味", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :favorite_things, "好きなもの" %>
+        </th>
+        <td>
+            <%= f.text_field :favorite_things, :placeholder => "好きなものや好きなことをなんでも", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :hate_things, "嫌いなもの" %>
+        </th>
+        <td>
+            <%= f.text_field :hate_things, :placeholder => "嫌いなものや嫌いなことをなんでも", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :strong_point, "長所" %>
+        </th>
+        <td>
+            <%= f.text_field :strong_point, :placeholder => "自分の長所を", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :week_point, "短所" %>
+        </th>
+        <td>
+            <%= f.text_field :week_point, :placeholder => "自分の短所を", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :special_skill, "得意なこと" %>
+        </th>
+        <td>
+            <%= f.text_field :special_skill, :placeholder => "得意なこと", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :week_things, "苦手なこと" %>
+        </th>
+        <td>
+            <%= f.text_field :week_things, :placeholder => "苦手なこと", size: 32%>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :happy_done_things, "されて嬉しいこと" %>
+        </th>
+        <td>
+            <%= f.text_field :happy_done_things, :placeholder => "されて嬉しいこと", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :disgusted_things, "されたら嫌なこと" %>
+        </th>
+        <td>
+            <%= f.text_field :disgusted_things, :placeholder => "されたら嫌いなこと", size: 32 %>
+        </td>
+    </tr>
+    <tr>
+        <th>
+            <%= f.label :freedom_message, "自由記入欄" %>
+        </th>
+        <td>
+            <%= f.text_field :freedom_message, :placeholder => "自由に書いてください", size: 32 %>
+        </td>
+    </tr>
+</table>
+

--- a/app/views/account/admin/result.html.erb
+++ b/app/views/account/admin/result.html.erb
@@ -11,8 +11,6 @@
             <th>生年月日</th>
             <th>入社日</th>
             <th>退職日</th>
-            <th>作成日</th>
-            <th>更新日</th>
         </tr>
         <% @searches.each do |x| %>
             <tr class="none">
@@ -20,13 +18,11 @@
                     <%= link_to "更新" , x.id.to_s+"/edit"%>
                 </td>
                 <td><%= x.id %></td>
-                <td><%= x.last_name %></td>
-                <td><%= x.first_name_phonetic %></td>
+                <td><%= x.last_name %> <%= x.first_name %></td>
+                <td><%= x.last_name_phonetic %> <%= x.first_name_phonetic %></td>
                 <td ><%= x.birth_year_month%></td>
                 <td><%= x.joining_year %></td>
                 <td><%= x.deleted_at.try(:strftime, "%Y/%m/%d") %></td>
-                <td><%= x.created_at.try(:strftime, "%Y/%m/%d") %></td>
-                <td><%= x.updated_at.try(:strftime, "%Y/%m/%d") %></td>
             </tr>
         <% end %>
     </table>

--- a/app/views/account/admin/show.html.erb
+++ b/app/views/account/admin/show.html.erb
@@ -22,8 +22,6 @@
             <th>生年月日</th>
             <th>入社日</th>
             <th>退職日</th>
-            <th>作成日</th>
-            <th>更新日</th>
         </tr>
         <% @m.each do |m| %>
         <tr class="none">
@@ -31,13 +29,11 @@
                 <%= link_to "更新" , m.id.to_s+"/edit"%>
             </td>
             <td><%= m.id %></td>
-            <td><%= m.last_name %></td>
-            <td><%= m.first_name_phonetic %></td>
+            <td><%= m.last_name %> <%= m.first_name %></td>
+            <td><%= m.last_name_phonetic %> <%= m.first_name_phonetic %></td>
             <td ><%= m.birth_year_month%></td>
             <td><%= m.joining_year %></td>
             <td><%= m.deleted_at.try(:strftime, "%Y/%m/%d") %></td>
-            <td><%= m.created_at.try(:strftime, "%Y/%m/%d") %></td>
-            <td><%= m.updated_at.try(:strftime, "%Y/%m/%d") %></td>
         </tr>
         <% end %>
     </table>


### PR DESCRIPTION
１。新規登録の時のファイル登録の項目名修正
２。新規登録の見た目がバラバラなのを直し
３。新規登録に必須項目の付け
４。管理者管理ページでの更新の時のフォームのみため直し
~５。一般メンバー一覧での順番見るやすいようにid順番で並べ替え~
５。一般メンバー一覧での順番見るやすいようにUPDATE_AT順番で並べ替え
６。従業員管理での名前をフルネームに現れるように（検索結果ページも）
７。従業員管理での作成日と更新日を項目削除